### PR TITLE
Fix: send message when has a dot on message

### DIFF
--- a/utelegram.py
+++ b/utelegram.py
@@ -134,7 +134,7 @@ class Bot():
 
         parameters = {
             'chat_id': chat_id,
-            'text': text,
+            'text': text.replace('.', '\.'),
             'parse_mode': parse_mode
         }
 


### PR DESCRIPTION
Fix the `can't parse character '.'` error

![photo_2021-11-30_13-37-29](https://user-images.githubusercontent.com/13322757/144090571-f3455af1-cbc3-461a-8909-5de10b0b39cc.jpg)
